### PR TITLE
Fix web server stop

### DIFF
--- a/src/harmony/service/web_server.clj
+++ b/src/harmony/service/web_server.clj
@@ -44,8 +44,8 @@
                           dev-mode? add-dev-interceptors
                           true (with-logging-interceptor))
             server (-> service-map
-                       (server/create-server)
-                       server/start)]
+                       (server/create-server))]
+        (server/start server)
         (log/info :web-server :started {:port port :dev-mode? dev-mode?})
         (assoc component :server server))))
 


### PR DESCRIPTION
It seems that the server/create-server call doesn't return what the code expects. Thus the stop function doesn't work.

This change ignores the return value from server/create-server
