### PR TITLE
Return empty db result as nil, not {}

### DIFF
--- a/src/harmony/bookings/db.clj
+++ b/src/harmony/bookings/db.clj
@@ -49,10 +49,9 @@
   :active-plan."
   [db {:keys [marketplaceId refId]}]
   (jdbc/with-db-transaction [tx db {:read-only? true}]
-    (if-let [b (fetch-bookable tx {:marketplaceId marketplaceId :refId refId})]
+    (when-let [b (fetch-bookable tx {:marketplaceId marketplaceId :refId refId})]
       {:bookable (dissoc b :activePlanId)
-       :active-plan (fetch-plan tx {:id (:activePlanId b)})}
-      {:bookable nil :active-plan nil})))
+       :active-plan (fetch-plan tx {:id (:activePlanId b)})})))
 
 (defn create-booking
   "Create a new booking iff it doesn't overlap with an existing

--- a/src/harmony/util/db.clj
+++ b/src/harmony/util/db.clj
@@ -60,12 +60,13 @@
   camelCased keywords) whose value should be converted to keyword."
   ([db-response] (format-result db-response nil))
   ([db-response {:keys [as-keywords]}]
-   (let [r (-> db-response
-               (map-values bytes-to-uuid)
-               (map-keys camel-case-key))]
-     (if (seq as-keywords)
-       (map-kvs r keywordize as-keywords)
-       r))))
+   (when (seq db-response)
+     (let [r (-> db-response
+                 (map-values bytes-to-uuid)
+                 (map-keys camel-case-key))]
+       (if (seq as-keywords)
+         (map-kvs r keywordize as-keywords)
+         r)))))
 
 (defn format-insert-data
   "Format an object for insertion to DB by converting all UUID values


### PR DESCRIPTION
This caused e.g. show-bookable API call to fail because we assumed a nil value to indicate no match but instead an empty map was passed through which then failed schema validation.