### PR TITLE
Show bookings endpoint

### DIFF
--- a/src/harmony/bookings/service.clj
+++ b/src/harmony/bookings/service.clj
@@ -32,12 +32,13 @@
         (assoc bookable :activePlan active-plan)))))
 
 (defn fetch-bookable
-  [db m-id ref-id]
-  (when-let [{:keys [bookable active-plan]}
+  [db params]
+  (when-let [{:keys [bookable active-plan bookings]}
              (db/fetch-bookable-with-plan
               db
-              {:marketplaceId m-id :refId ref-id})]
-    (assoc bookable :activePlan active-plan)))
+              params)]
+    (cond-> (assoc bookable :activePlan active-plan)
+      bookings (assoc :bookings bookings))))
 
 (defn- free-dates [start end bookings]
   (let [booking-is (map #(t/interval (time/midnight-date-time (:start %))

--- a/src/harmony/service/web/swagger.clj
+++ b/src/harmony/service/web/swagger.clj
@@ -76,6 +76,18 @@
                 vec)
            x)))))
 
+(defn- keyword-seq-matcher [schema]
+  (when (= [s/Keyword] schema)
+    (coerce/safe
+     (fn [x]
+       (if (string? x)
+         (->> (str/split x #",")
+              (map str/trim)
+              (remove empty?)
+              (map keyword)
+              vec)
+         x)))))
+
 (def api-date-time-formatter (format/formatters :date-time))
 
 (defn- date-matcher [schema]
@@ -92,6 +104,7 @@
 (def default-coercions
   (coerce/first-matcher [date-matcher
                          uuid-seq-matcher
+                         keyword-seq-matcher
                          coerce/string-coercion-matcher
                          num-seq-matcher]))
 

--- a/src/harmony/util/time.clj
+++ b/src/harmony/util/time.clj
@@ -4,16 +4,16 @@
             [clj-time.coerce :as coerce]))
 
 (defn midnight-date-time
-  "Given an inst (java.util.Date) clear time and return as DateTime
-  with time 00:00:000."
+  "Given an inst (java.util.Date) or a DateTime clear time and return
+  as DateTime with time 00:00:000."
   [inst]
   (let [dt (coerce/to-date-time inst)
         [year month day] ((juxt t/year t/month t/day) dt)]
     (t/date-midnight year month day)))
 
 (defn midnight-date
-  "Given an inst (java.util.Date) clear time and return as inst with
-  time 00:00:000."
+  "Given an inst (java.util.Date) or a DateTime clear time and return
+  as inst with time 00:00:000."
   [inst]
   (-> inst midnight-date-time coerce/to-date))
 


### PR DESCRIPTION
Show bookable endpoint now accepts three new optional parameters: include, start and end. Using the include parameter caller can specify a set of resources to be included int he response (supports bookings now, blocks later). start and end are filters that limit the time range for fetching included resources. The same time range filter is shared between all included resources (for which time range filter is applicable).