### PR TITLE
Don't crash if there are no blocks to delete

### DIFF
--- a/src/harmony/bookings/db.clj
+++ b/src/harmony/bookings/db.clj
@@ -124,22 +124,27 @@
 (defn fetch-blocks-by-ids
   ([db query-params] (fetch-blocks-by-ids db query-params {}))
   ([db {:keys [ids bookableId]} {:keys [cols]}]
-   (let [qp (format-params
-             {:ids ids :bookableId bookableId}
-             {:cols cols :default-cols #{:id
-                                         :marketplaceId
-                                         :bookableId
-                                         :start
-                                         :end}})
+   (if (seq ids)
+     (let [qp (format-params
+               {:ids ids :bookableId bookableId}
+               {:cols cols :default-cols #{:id
+                                           :marketplaceId
+                                           :bookableId
+                                           :start
+                                           :end}})
 
-         blocks (select-exceptions-by-ids-bookable db qp)]
-     (map #(format-result % {:as-keywords #{:type}}) blocks))))
+           blocks (select-exceptions-by-ids-bookable db qp)]
+       (map #(format-result % {:as-keywords #{:type}}) blocks))
+     [])))
 
 (defn remove-blocks [db blocks]
   "Remove block"
   (let [ids (map :id blocks)]
-    (update-exceptions-deleted-by-ids db (format-params {:deleted true :ids ids}))
-    ids))
+    (if (seq ids)
+      (do
+        (update-exceptions-deleted-by-ids db (format-params {:deleted true :ids ids}))
+        ids)
+      [])))
 
 (defn create-blocks
   "Create a new block"


### PR DESCRIPTION
This PR fixes an issue which may occure if client sends `deleteBlocks` request with block IDs that don't exist anymore.

**Steps to reproduce:**

To reproduce the issue, you need to have two tabs open.

1. In tab 1, go to listing page, open availability calendar
1. In tab 1, block one day and save
1. In tab 1, reopen the calendar
1. In tab 2, go to listing page, open availability calendar
1. In tab 2, delete one blocked day and save
1. In tab 1, try to delete the same blocked day and save

**Expected result**: Success

**Actual result**: The delete operation fails because the block has been delete already (in tab 2)